### PR TITLE
Add package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "order.less",
+  "version": "1.0.0",
+  "homepage": "https://github.com/chromice/order.less",
+  "description": "Baseline alignment, column grids and modular scales.",
+  "main": "./order.less",
+  "keywords": [
+    "grid",
+    "baseline",
+    "rhythm"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "examples",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Including a package.json file makes it easy to check this project out using npm if you prefer that over bower. Then I can simply run `npm install chromice/order.less` to install from npm.

Might be worth submitting to npm as a module, which would simply make the command `npm install order.less` but I'll leave that up to you :)
